### PR TITLE
MR1L0 Encoder to Arbiter, Variable Cooling Hardware.

### DIFF
--- a/lcls-plc-lfe-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/PMPS_PRE.xti
+++ b/lcls-plc-lfe-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/PMPS_PRE.xti
@@ -363,6 +363,10 @@
 								<BitSize>16</BitSize>
 							</DataType>
 							<DataType>
+								<Name>ULINT</Name>
+								<BitSize>64</BitSize>
+							</DataType>
+							<DataType>
 								<Name>USINT</Name>
 								<BitSize>8</BitSize>
 							</DataType>
@@ -377,6 +381,120 @@
 							</DataType>
 							<DataType>
 								<Name>DT1A08</Name>
+								<BitSize>304</BitSize>
+								<SubItem>
+									<SubIdx>0</SubIdx>
+									<Name>SubIndex 000</Name>
+									<Type>USINT</Type>
+									<BitSize>8</BitSize>
+									<BitOffs>0</BitOffs>
+									<Flags>
+										<Access WriteRestrictions="PreOP">rw</Access>
+										<Category>o</Category>
+									</Flags>
+								</SubItem>
+								<SubItem>
+									<SubIdx>1</SubIdx>
+									<Name>SubIndex 001</Name>
+									<Type>UDINT</Type>
+									<BitSize>32</BitSize>
+									<BitOffs>16</BitOffs>
+									<Flags>
+										<Access WriteRestrictions="PreOP">rw</Access>
+										<Category>o</Category>
+									</Flags>
+								</SubItem>
+								<SubItem>
+									<SubIdx>2</SubIdx>
+									<Name>SubIndex 002</Name>
+									<Type>UDINT</Type>
+									<BitSize>32</BitSize>
+									<BitOffs>48</BitOffs>
+									<Flags>
+										<Access WriteRestrictions="PreOP">rw</Access>
+										<Category>o</Category>
+									</Flags>
+								</SubItem>
+								<SubItem>
+									<SubIdx>3</SubIdx>
+									<Name>SubIndex 003</Name>
+									<Type>UDINT</Type>
+									<BitSize>32</BitSize>
+									<BitOffs>80</BitOffs>
+									<Flags>
+										<Access WriteRestrictions="PreOP">rw</Access>
+										<Category>o</Category>
+									</Flags>
+								</SubItem>
+								<SubItem>
+									<SubIdx>4</SubIdx>
+									<Name>SubIndex 004</Name>
+									<Type>UDINT</Type>
+									<BitSize>32</BitSize>
+									<BitOffs>112</BitOffs>
+									<Flags>
+										<Access WriteRestrictions="PreOP">rw</Access>
+										<Category>o</Category>
+									</Flags>
+								</SubItem>
+								<SubItem>
+									<SubIdx>5</SubIdx>
+									<Name>SubIndex 005</Name>
+									<Type>UDINT</Type>
+									<BitSize>32</BitSize>
+									<BitOffs>144</BitOffs>
+									<Flags>
+										<Access WriteRestrictions="PreOP">rw</Access>
+										<Category>o</Category>
+									</Flags>
+								</SubItem>
+								<SubItem>
+									<SubIdx>6</SubIdx>
+									<Name>SubIndex 006</Name>
+									<Type>UDINT</Type>
+									<BitSize>32</BitSize>
+									<BitOffs>176</BitOffs>
+									<Flags>
+										<Access WriteRestrictions="PreOP">rw</Access>
+										<Category>o</Category>
+									</Flags>
+								</SubItem>
+								<SubItem>
+									<SubIdx>7</SubIdx>
+									<Name>SubIndex 007</Name>
+									<Type>UDINT</Type>
+									<BitSize>32</BitSize>
+									<BitOffs>208</BitOffs>
+									<Flags>
+										<Access WriteRestrictions="PreOP">rw</Access>
+										<Category>o</Category>
+									</Flags>
+								</SubItem>
+								<SubItem>
+									<SubIdx>8</SubIdx>
+									<Name>SubIndex 008</Name>
+									<Type>UDINT</Type>
+									<BitSize>32</BitSize>
+									<BitOffs>240</BitOffs>
+									<Flags>
+										<Access WriteRestrictions="PreOP">rw</Access>
+										<Category>o</Category>
+									</Flags>
+								</SubItem>
+								<SubItem>
+									<SubIdx>9</SubIdx>
+									<Name>SubIndex 009</Name>
+									<Type>UDINT</Type>
+									<BitSize>32</BitSize>
+									<BitOffs>272</BitOffs>
+									<Flags>
+										<Access WriteRestrictions="PreOP">rw</Access>
+										<Category>o</Category>
+									</Flags>
+								</SubItem>
+							</DataType>
+							<DataType>
+								<Name>DT1608</Name>
 								<BitSize>272</BitSize>
 								<SubItem>
 									<SubIdx>0</SubIdx>
@@ -548,7 +666,7 @@
 							</DataType>
 							<DataType>
 								<Name>DT6000</Name>
-								<BitSize>1776</BitSize>
+								<BitSize>1840</BitSize>
 								<SubItem>
 									<SubIdx>0</SubIdx>
 									<Name>SubIndex 000</Name>
@@ -566,6 +684,18 @@
 									<Type>ARRAY [0..219] OF BYTE</Type>
 									<BitSize>1760</BitSize>
 									<BitOffs>16</BitOffs>
+									<Flags>
+										<Access>rw</Access>
+										<Category>o</Category>
+										<PdoMapping>R</PdoMapping>
+									</Flags>
+								</SubItem>
+								<SubItem>
+									<SubIdx>2</SubIdx>
+									<Name>MR1L0_Pitch_ENC</Name>
+									<Type>ULINT</Type>
+									<BitSize>64</BitSize>
+									<BitOffs>1776</BitOffs>
 									<Flags>
 										<Access>rw</Access>
 										<Category>o</Category>
@@ -606,12 +736,12 @@
 								<Index>#x1a08</Index>
 								<Name>IO Outputs</Name>
 								<Type>DT1A08</Type>
-								<BitSize>272</BitSize>
+								<BitSize>304</BitSize>
 								<Info>
 									<SubItem>
 										<Name>SubIndex 000</Name>
 										<Info>
-											<DefaultData>08</DefaultData>
+											<DefaultData>09</DefaultData>
 										</Info>
 									</SubItem>
 									<SubItem>
@@ -662,6 +792,12 @@
 											<DefaultData>50000000</DefaultData>
 										</Info>
 									</SubItem>
+									<SubItem>
+										<Name>SubIndex 009</Name>
+										<Info>
+											<DefaultData>40020060</DefaultData>
+										</Info>
+									</SubItem>
 								</Info>
 								<Flags>
 									<Access>ro</Access>
@@ -671,7 +807,7 @@
 							<Object>
 								<Index>#x1608</Index>
 								<Name>IO Inputs</Name>
-								<Type>DT1A08</Type>
+								<Type>DT1608</Type>
 								<BitSize>272</BitSize>
 								<Info>
 									<SubItem>
@@ -796,20 +932,26 @@
 								<Index>#x6000</Index>
 								<Name>Outputs</Name>
 								<Type>DT6000</Type>
-								<BitSize>1776</BitSize>
+								<BitSize>1840</BitSize>
 								<Info>
 									<SubItem>
 										<Name>SubIndex 000</Name>
 										<Info>
 											<MinValue>#x0</MinValue>
 											<MaxValue>#xff</MaxValue>
-											<DefaultValue>#x1</DefaultValue>
+											<DefaultValue>#x2</DefaultValue>
 										</Info>
 									</SubItem>
 									<SubItem>
 										<Name>RequestedBP</Name>
 										<Info>
 											<DefaultData>00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000</DefaultData>
+										</Info>
+									</SubItem>
+									<SubItem>
+										<Name>MR1L0_Pitch_ENC</Name>
+										<Info>
+											<DefaultData>0000000000000000</DefaultData>
 										</Info>
 									</SubItem>
 								</Info>
@@ -850,7 +992,7 @@
 		<EtherCAT SlaveType="3" AdsServerAddress="ac15581e0205eb03" PdiType="#x0008" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="47" EoeType="1" FoeType="1" VendorId="#x00000002" ProductCode="#x1a273052" RevisionNo="#x00050000" InfoDataAddr="true" InfoDataNetId="true" TimeoutMailbox2="2000" GenerateOwnNetId="true" CheckRevisionNoType="3" PortPhys="51" DcTimeLoopControlOnly="true" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL6695 EtherCAT Bridge terminal (Primary)" Desc="EL6695">
 			<SyncMan>0010000426000100010000008000da050004001026010000</SyncMan>
 			<SyncMan>0016000422000100020000008000da050004001622010000</SyncMan>
-			<SyncMan>001cdc006400010003000000000000000000001c64010000</SyncMan>
+			<SyncMan>001ce4006400010003000000000000000000001c64010000</SyncMan>
 			<SyncMan>008ede002000010004000000000000000200008e20010000</SyncMan>
 			<Fmmu>0000000000000000001c00020100000001000000000000000000000000000000</Fmmu>
 			<Fmmu>0000000000000000008e00010100000002000000000000000000000000000000</Fmmu>
@@ -1002,6 +1144,9 @@
 			<Pdo Name="IO Outputs" Index="#x1608" InOut="1" Flags="#x0020" SyncMan="2">
 				<Entry Name="RequestedBP" BitLen="240" Index="#x7000" Sub="#x01">
 					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
+				</Entry>
+				<Entry Name="MR1L0_Pitch_ENC" BitLen="64" Index="#x7000" Sub="#x02">
+					<Type>ULINT</Type>
 				</Entry>
 			</Pdo>
 			<CoeProfile ProfileNo="5001"/>

--- a/lcls-plc-lfe-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/Term 5 (EK1122).xti
+++ b/lcls-plc-lfe-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/Term 5 (EK1122).xti
@@ -13,5 +13,8 @@
 		<Box File="EK1100_M2L0.xti" Id="19">
 			<EtherCAT PortABoxInfo="#x01000005"/>
 		</Box>
+		<Box File="Box 69 (EP2008-0001).xti" Id="69">
+			<EtherCAT PortABoxInfo="#x02000013"/>
+		</Box>
 	</Box>
 </TcSmItem>

--- a/lcls-plc-lfe-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/Term 5 (EK1122)/Box 69 (EP2008-0001).xti
+++ b/lcls-plc-lfe-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/Term 5 (EK1122)/Box 69 (EP2008-0001).xti
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CFlbTermDef" SubType="9099">
+	<ImageDatas>
+		<ImageData Id="1000">424de6000000000000007600000028000000100000000e000000010004000000000070000000c30e0000c30e000010000000100000000000ff00ff00ff00ff000000ffff000000ff000000ffff0000008000800080008000000080800000008000000080800080808000c0c0c000ffffff00000000001111111111111111fffffffffffffffffcfcfcfcfffff44ff4f4f4f4fffff44ffffffffffffffffffffffffffffffffffcfcfcfcfffff44ff4f4f4f4fffff44fffffffffffffffff00000011111111110000001111111111000000111111111100000011111111110000001111111111</ImageData>
+	</ImageDatas>
+	<Box Id="69" BoxType="9099">
+		<Name>__FILENAME__</Name>
+		<ImageId>1000</ImageId>
+		<EtherCAT SlaveType="1" PdiType="#x0304" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x07d84052" RevisionNo="#x00130001" RepeatSupport="true" PortPhys="17" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EP2008-0001 8 Ch. Dig. Output 24V, 0,5A, M8" Desc="EP2008-0001">
+			<SyncMan>000f01004400010003000000010001000100000f44090000</SyncMan>
+			<Fmmu>0000000000000000000f00020100000001000000000000000000000000000000</Fmmu>
+			<Pdo Name="Channel 1" Index="#x1600" InOut="1" Flags="#x0011" SyncMan="0">
+				<Entry Name="Output" Index="#x7000" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+			</Pdo>
+			<Pdo Name="Channel 2" Index="#x1601" InOut="1" Flags="#x0011" SyncMan="0">
+				<Entry Name="Output" Index="#x7010" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+			</Pdo>
+			<Pdo Name="Channel 3" Index="#x1602" InOut="1" Flags="#x0011" SyncMan="0">
+				<Entry Name="Output" Index="#x7020" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+			</Pdo>
+			<Pdo Name="Channel 4" Index="#x1603" InOut="1" Flags="#x0011" SyncMan="0">
+				<Entry Name="Output" Index="#x7030" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+			</Pdo>
+			<Pdo Name="Channel 5" Index="#x1604" InOut="1" Flags="#x0011" SyncMan="0">
+				<Entry Name="Output" Index="#x7040" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+			</Pdo>
+			<Pdo Name="Channel 6" Index="#x1605" InOut="1" Flags="#x0011" SyncMan="0">
+				<Entry Name="Output" Index="#x7050" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+			</Pdo>
+			<Pdo Name="Channel 7" Index="#x1606" InOut="1" Flags="#x0011" SyncMan="0">
+				<Entry Name="Output" Index="#x7060" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+			</Pdo>
+			<Pdo Name="Channel 8" Index="#x1607" InOut="1" Flags="#x0011" SyncMan="0">
+				<Entry Name="Output" Index="#x7070" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+			</Pdo>
+		</EtherCAT>
+	</Box>
+</TcSmItem>

--- a/lcls-plc-lfe-optics/_Config/PLC/lfe_optics.xti
+++ b/lcls-plc-lfe-optics/_Config/PLC/lfe_optics.xti
@@ -775,15 +775,15 @@ External Setpoint Generation:
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{DA90D983-4828-44E1-A6E4-C44950A398FB}" Namespace="lcls_twincat_motion" AutoDeleteType="true">EL5042_Status</Name>
+			<Name GUID="{51EA3E75-56D5-4CE8-8D87-5709D5656A63}" Namespace="lcls_twincat_motion" AutoDeleteType="true">EL5042_Status</Name>
 			<BitSize>0</BitSize>
 			<BaseType GUID="{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}"/>
 			<Hides>
-				<Hide GUID="{116A4D53-0821-4DE7-B151-63406A4263C7}"/>
+				<Hide GUID="{DA90D983-4828-44E1-A6E4-C44950A398FB}"/>
 			</Hides>
 		</DataType>
 		<DataType>
-			<Name GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
+			<Name GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
 			<Comment>
 				<![CDATA[Renishaw BiSS-C absolute encoder used with an EL5042]]>
 			</Comment>
@@ -805,7 +805,7 @@ External Setpoint Generation:
 			</SubItem>
 			<SubItem>
 				<Name>Status</Name>
-				<Type GUID="{DA90D983-4828-44E1-A6E4-C44950A398FB}" Namespace="lcls_twincat_motion">EL5042_Status</Type>
+				<Type GUID="{51EA3E75-56D5-4CE8-8D87-5709D5656A63}" Namespace="lcls_twincat_motion">EL5042_Status</Type>
 				<Comment>
 					<![CDATA[Status struct placeholder]]>
 				</Comment>
@@ -822,7 +822,7 @@ External Setpoint Generation:
 				<BitOffs>64</BitOffs>
 			</SubItem>
 			<Hides>
-				<Hide GUID="{FD265F28-FE38-4152-9AA3-632C308752BC}"/>
+				<Hide GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}"/>
 			</Hides>
 		</DataType>
 		<DataType>
@@ -2257,7 +2257,7 @@ External Setpoint Generation:
 					<Comment>
 						<![CDATA[ Encoders]]>
 					</Comment>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -2279,7 +2279,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M1L0.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -2301,7 +2301,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M1L0.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -2323,7 +2323,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M1L0.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -2387,7 +2387,7 @@ External Setpoint Generation:
 					<Comment>
 						<![CDATA[ Encoders]]>
 					</Comment>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -2409,7 +2409,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L0GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -2431,7 +2431,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L0GantryStats.homs.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -2453,7 +2453,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L0GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -3595,7 +3595,7 @@ External Setpoint Generation:
 					<Comment>
 						<![CDATA[ Encoders]]>
 					</Comment>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -3617,7 +3617,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M2L0.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -3639,7 +3639,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M2L0.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -3661,7 +3661,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M2L0.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -3725,7 +3725,7 @@ External Setpoint Generation:
 					<Comment>
 						<![CDATA[ Encoders]]>
 					</Comment>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -3747,7 +3747,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L0GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -3769,7 +3769,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L0GantryStats.homs.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -3791,7 +3791,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L0GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{1BBEC22E-57FC-41BE-B0CA-C76AA201A4F7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{5C7FC0AD-9A77-4E90-A359-C1CC78D7CFA7}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 					<SubVar>
 						<Name>Count</Name>
 						<Comment>
@@ -4587,6 +4587,13 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
+					<Name>Main.nMR1L0_Pitch_ENC_PMPS</Name>
+					<Comment>
+						<![CDATA[exclusion range 0,12 AND 27,90]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
 					<Name>GVL_PMPS.g_FastFaultOutput1.q_xFastFaultOut</Name>
 					<Type>BOOL</Type>
 				</Var>
@@ -4621,8 +4628,8 @@ External Setpoint Generation:
 			</Vars>
 			<TaskPouOids>
 				<TaskPouOid Prio="1" OTCID="#x08502001"/>
-				<TaskPouOid Prio="3" OTCID="#x08502002"/>
 				<TaskPouOid Prio="20" OTCID="#x08502003"/>
+				<TaskPouOid Prio="3" OTCID="#x08502002"/>
 			</TaskPouOids>
 		</Instance>
 	</Project>
@@ -4637,6 +4644,7 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^Main.fbArbiterIO.xTxPDO_state" VarB="SYNC Inputs^TxPDO state" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^Main.fbArbiterIO.xTxPDO_toggle" VarB="SYNC Inputs^TxPDO toggle" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^Main.fbArbiterIO.q_stRequestedBP" VarB="IO Outputs^RequestedBP" AutoLink="true"/>
+				<Link VarA="PlcTask Outputs^Main.nMR1L0_Pitch_ENC_PMPS" VarB="IO Outputs^MR1L0_Pitch_ENC" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1L0^EL1004_M1L0_STO">
 				<Link VarA="PlcTask Inputs^Main.M1L0.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true"/>

--- a/lcls-plc-lfe-optics/lfe_optics/POUs/Main.TcPOU
+++ b/lcls-plc-lfe-optics/lfe_optics/POUs/Main.TcPOU
@@ -411,7 +411,8 @@ VAR
             nNiPosition:= 16018200,
             fNiDelta:= 1000 ,
             fNiVelocity:= 100); //exclusion range 0,12 AND 27,90
-
+    {attribute 'TcLinkTo' := 'TIIB[PMPS_PRE]^IO Outputs^MR1L0_Pitch_ENC'}
+    nMR1L0_Pitch_ENC_PMPS AT %Q* : ULINT;
 
 
 END_VAR]]></Declaration>
@@ -630,7 +631,7 @@ fbArbiterIO(Arbiter := GVL_PMPS.g_fbArbiter1, fbFFHWO := GVL_PMPS.g_FastFaultOut
 GVL_PMPS.g_FastFaultOutput1.Execute(i_xVeto:=);
 GVL_PMPS.g_FastFaultOutput2.Execute(i_xVeto:=);
 
-]]></ST>
+ nMR1L0_Pitch_ENC_PMPS := M1.nRawEncoderULINT;]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-lfe-optics/lfe_optics/lfe_optics.tmc
+++ b/lcls-plc-lfe-optics/lfe_optics/lfe_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{64B0D4D1-1A96-94EF-4E3F-B90371793658}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D7913D0B-C39F-45DF-B7C2-55B091A85493}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -4026,31 +4026,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>81488264</GetCodeOffs>
+        <GetCodeOffs>81488272</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>81488300</GetCodeOffs>
+        <GetCodeOffs>81488308</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81488308</GetCodeOffs>
+        <GetCodeOffs>81488316</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81488288</GetCodeOffs>
+        <GetCodeOffs>81488296</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>81488304</GetCodeOffs>
+        <GetCodeOffs>81488312</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -5289,15 +5289,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81488204</GetCodeOffs>
-        <SetCodeOffs>81488228</SetCodeOffs>
+        <GetCodeOffs>81488212</GetCodeOffs>
+        <SetCodeOffs>81488236</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>81488244</GetCodeOffs>
-        <SetCodeOffs>81488256</SetCodeOffs>
+        <GetCodeOffs>81488252</GetCodeOffs>
+        <SetCodeOffs>81488264</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>ExtendName</Name>
@@ -5543,37 +5543,37 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>81488356</GetCodeOffs>
+        <GetCodeOffs>81488364</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81488336</GetCodeOffs>
+        <GetCodeOffs>81488344</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81488424</GetCodeOffs>
+        <GetCodeOffs>81488432</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81488428</GetCodeOffs>
+        <GetCodeOffs>81488436</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>81488384</GetCodeOffs>
+        <GetCodeOffs>81488392</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>81488432</GetCodeOffs>
+        <GetCodeOffs>81488440</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -6172,7 +6172,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>81488456</GetCodeOffs>
+        <GetCodeOffs>81488464</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -37829,7 +37829,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>81493216</GetCodeOffs>
+        <GetCodeOffs>81493224</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="45">__getnTimestamp</Name>
@@ -39528,31 +39528,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>81492360</GetCodeOffs>
+        <GetCodeOffs>81492368</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>81492404</GetCodeOffs>
+        <GetCodeOffs>81492412</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81492368</GetCodeOffs>
+        <GetCodeOffs>81492376</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>81492392</GetCodeOffs>
+        <GetCodeOffs>81492400</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>81492412</GetCodeOffs>
+        <GetCodeOffs>81492420</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -46030,6 +46030,44 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Hides>
     </DataType>
     <DataType>
+      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
+      <DisplayName TxtId="">Log event</DisplayName>
+      <EventId>
+        <Name Id="0">Critical</Name>
+        <DisplayName TxtId="">Critical</DisplayName>
+        <Severity>Critical</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1">Error</Name>
+        <DisplayName TxtId="">Error</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="2">Warning</Name>
+        <DisplayName TxtId="">Warning</DisplayName>
+        <Severity>Warning</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="3">Info</Name>
+        <DisplayName TxtId="">Info</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="4">Verbose</Name>
+        <DisplayName TxtId="">Verbose</DisplayName>
+        <Severity>Verbose</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
+        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
+        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
+        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
+      </Hides>
+    </DataType>
+    <DataType>
       <Name GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}" TcBaseType="true" CName="TcSystemEventClass">TcSystemEventClass</Name>
       <DisplayName TxtId="">TcSystemEventClass</DisplayName>
       <EventId>
@@ -46835,44 +46873,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Hide GUID="{3FEAA938-D042-4B1E-8ADD-BB2F7BE872B0}"/>
       </Hides>
     </DataType>
-    <DataType>
-      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
-      <DisplayName TxtId="">Log event</DisplayName>
-      <EventId>
-        <Name Id="0">Critical</Name>
-        <DisplayName TxtId="">Critical</DisplayName>
-        <Severity>Critical</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="1">Error</Name>
-        <DisplayName TxtId="">Error</DisplayName>
-        <Severity>Error</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="2">Warning</Name>
-        <DisplayName TxtId="">Warning</DisplayName>
-        <Severity>Warning</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="3">Info</Name>
-        <DisplayName TxtId="">Info</DisplayName>
-        <Severity>Info</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="4">Verbose</Name>
-        <DisplayName TxtId="">Verbose</DisplayName>
-        <Severity>Verbose</Severity>
-      </EventId>
-      <Hides>
-        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
-        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
-        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
-        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
-        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
-        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
-        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
-      </Hides>
-    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{485084E3-FC90-4356-A525-58C175F6B1D6}" TcSmClass="TComPlcObjDef">
@@ -46976,7 +46976,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651736640</BitOffs>
+            <BitOffs>651736704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M2L0</Name>
@@ -46992,7 +46992,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651737024</BitOffs>
+            <BitOffs>651737088</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -47014,7 +47014,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651736832</BitOffs>
+            <BitOffs>651736896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M2L0</Name>
@@ -47030,7 +47030,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651737216</BitOffs>
+            <BitOffs>651737280</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -47062,7 +47062,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649778944</BitOffs>
+            <BitOffs>649779008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1L0</Name>
@@ -47073,7 +47073,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649781456</BitOffs>
+            <BitOffs>649781520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_RXBuffer_M2L0</Name>
@@ -47085,7 +47085,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649783968</BitOffs>
+            <BitOffs>649784032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M2L0</Name>
@@ -47096,7 +47096,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649786480</BitOffs>
+            <BitOffs>649786544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -47110,7 +47110,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651739680</BitOffs>
+            <BitOffs>651739744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -47124,7 +47124,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651741728</BitOffs>
+            <BitOffs>651741792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -47138,7 +47138,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651744832</BitOffs>
+            <BitOffs>651744896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -47159,7 +47159,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651744992</BitOffs>
+            <BitOffs>651745056</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -47212,7 +47212,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649788992</BitOffs>
+            <BitOffs>649789056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.M2L0_Pitch</Name>
@@ -47246,7 +47246,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649792896</BitOffs>
+            <BitOffs>649792960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -47260,7 +47260,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651744864</BitOffs>
+            <BitOffs>651744928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -47274,7 +47274,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651744896</BitOffs>
+            <BitOffs>651744960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -47295,7 +47295,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651745696</BitOffs>
+            <BitOffs>651745760</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -50338,7 +50338,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649791424</BitOffs>
+            <BitOffs>649791488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0.fM1L0_Flow_1.iRaw</Name>
@@ -50351,7 +50351,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649791520</BitOffs>
+            <BitOffs>649791584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0.fM1L0_Flow_2.iRaw</Name>
@@ -50364,7 +50364,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649791904</BitOffs>
+            <BitOffs>649791968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0.fM1L0_Press_1.iRaw</Name>
@@ -50377,7 +50377,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649792288</BitOffs>
+            <BitOffs>649792352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.M2L0_Pitch.diEncCnt</Name>
@@ -50390,7 +50390,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649795328</BitOffs>
+            <BitOffs>649795392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.fM2L0_Flow_1.iRaw</Name>
@@ -50403,7 +50403,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649795424</BitOffs>
+            <BitOffs>649795488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.fM2L0_Flow_2.iRaw</Name>
@@ -50416,7 +50416,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649795808</BitOffs>
+            <BitOffs>649795872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.fM2L0_Press_1.iRaw</Name>
@@ -50429,7 +50429,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649796192</BitOffs>
+            <BitOffs>649796256</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -51158,6 +51158,23 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>642800448</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>Main.nMR1L0_Pitch_ENC_PMPS</Name>
+            <Comment>exclusion range 0,12 AND 27,90</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[PMPS_PRE]^IO Outputs^MR1L0_Pitch_ENC</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>649670848</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput1.q_xFastFaultOut</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -51175,7 +51192,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649797064</BitOffs>
+            <BitOffs>649797128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput2.q_xFastFaultOut</Name>
@@ -51195,7 +51212,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>650292360</BitOffs>
+            <BitOffs>650292424</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -59489,7 +59506,7 @@ bM2L0PitchBusy : BOOL;
                 <String>B4C/Ni</String>
               </SubItem>
             </Default>
-            <BitOffs>649673248</BitOffs>
+            <BitOffs>649673312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_CoatingProtections.fbStripProtMR2L0</Name>
@@ -59517,7 +59534,7 @@ bM2L0PitchBusy : BOOL;
                 <String>B4C</String>
               </SubItem>
             </Default>
-            <BitOffs>649725728</BitOffs>
+            <BitOffs>649725792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0.fM1L0_Flow_1</Name>
@@ -59533,7 +59550,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649791488</BitOffs>
+            <BitOffs>649791552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0.fM1L0_Flow_1_val</Name>
@@ -59552,7 +59569,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649791808</BitOffs>
+            <BitOffs>649791872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0.fM1L0_Flow_2</Name>
@@ -59567,7 +59584,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649791872</BitOffs>
+            <BitOffs>649791936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0.fM1L0_Flow_2_val</Name>
@@ -59586,7 +59603,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649792192</BitOffs>
+            <BitOffs>649792256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0.fM1L0_Press_1</Name>
@@ -59601,7 +59618,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649792256</BitOffs>
+            <BitOffs>649792320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0.fM1L0_Press_1_val</Name>
@@ -59620,7 +59637,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649792576</BitOffs>
+            <BitOffs>649792640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0_Constants.nYUP_ENC_REF</Name>
@@ -59636,7 +59653,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649792640</BitOffs>
+            <BitOffs>649792704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0_Constants.nYDWN_ENC_REF</Name>
@@ -59650,7 +59667,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649792704</BitOffs>
+            <BitOffs>649792768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0_Constants.nXUP_ENC_REF</Name>
@@ -59664,7 +59681,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649792768</BitOffs>
+            <BitOffs>649792832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1L0_Constants.nXDWN_ENC_REF</Name>
@@ -59678,7 +59695,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649792832</BitOffs>
+            <BitOffs>649792896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.fM2L0_Flow_1</Name>
@@ -59694,7 +59711,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649795392</BitOffs>
+            <BitOffs>649795456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.fM2L0_Flow_1_val</Name>
@@ -59713,7 +59730,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649795712</BitOffs>
+            <BitOffs>649795776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.fM2L0_Flow_2</Name>
@@ -59728,7 +59745,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649795776</BitOffs>
+            <BitOffs>649795840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.fM2L0_Flow_2_val</Name>
@@ -59747,7 +59764,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649796096</BitOffs>
+            <BitOffs>649796160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.fM2L0_Press_1</Name>
@@ -59762,7 +59779,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649796160</BitOffs>
+            <BitOffs>649796224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0.fM2L0_Press_1_val</Name>
@@ -59781,7 +59798,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649796480</BitOffs>
+            <BitOffs>649796544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0_Constants.nYUP_ENC_REF</Name>
@@ -59797,7 +59814,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649796544</BitOffs>
+            <BitOffs>649796608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0_Constants.nYDWN_ENC_REF</Name>
@@ -59811,7 +59828,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649796608</BitOffs>
+            <BitOffs>649796672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0_Constants.nXUP_ENC_REF</Name>
@@ -59825,7 +59842,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649796672</BitOffs>
+            <BitOffs>649796736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2L0_Constants.nXDWN_ENC_REF</Name>
@@ -59839,7 +59856,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649796736</BitOffs>
+            <BitOffs>649796800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput1</Name>
@@ -59871,7 +59888,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>649796800</BitOffs>
+            <BitOffs>649796864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput2</Name>
@@ -59902,7 +59919,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650292096</BitOffs>
+            <BitOffs>650292160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_fbArbiter1</Name>
@@ -59922,7 +59939,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>650787392</BitOffs>
+            <BitOffs>650787456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_fbArbiter2</Name>
@@ -59942,7 +59959,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651262016</BitOffs>
+            <BitOffs>651262080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -59972,7 +59989,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651737408</BitOffs>
+            <BitOffs>651737472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -60002,7 +60019,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651737472</BitOffs>
+            <BitOffs>651737536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -60016,7 +60033,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651737536</BitOffs>
+            <BitOffs>651737600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -60030,7 +60047,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651737568</BitOffs>
+            <BitOffs>651737632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -60044,7 +60061,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651737600</BitOffs>
+            <BitOffs>651737664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -60165,7 +60182,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651737632</BitOffs>
+            <BitOffs>651737696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -60183,7 +60200,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651741760</BitOffs>
+            <BitOffs>651741824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -60197,7 +60214,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651744928</BitOffs>
+            <BitOffs>651744992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -60211,7 +60228,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651744960</BitOffs>
+            <BitOffs>651745024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -60232,7 +60249,30 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651746400</BitOffs>
+            <BitOffs>651746464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
+            <Comment> ST_LCLSGeneralEventClass</Comment>
+            <BitSize>960</BitSize>
+            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
+            <Properties>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>651778144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -60301,7 +60341,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651762592</BitOffs>
+            <BitOffs>651791776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -60370,7 +60410,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651762720</BitOffs>
+            <BitOffs>651791904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -60439,7 +60479,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651762848</BitOffs>
+            <BitOffs>651792032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -60508,7 +60548,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651762976</BitOffs>
+            <BitOffs>651792160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -60577,7 +60617,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651763104</BitOffs>
+            <BitOffs>651792288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -60646,30 +60686,7 @@ bM2L0PitchBusy : BOOL;
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>651763232</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
-            <Comment> ST_LCLSGeneralEventClass</Comment>
-            <BitSize>960</BitSize>
-            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
-            <Properties>
-              <Property>
-                <Name>tc_no_symbol</Name>
-                <Value>unused</Value>
-              </Property>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>suppress_warning_0</Name>
-                <Value>C0228</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>651793696</BitOffs>
+            <BitOffs>651792416</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -60731,6 +60748,9 @@ bM2L0PitchBusy : BOOL;
       <Deployment/>
       <EventClasses>
         <EventClass>
+          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
+        </EventClass>
+        <EventClass>
           <Type GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}">TcSystemEventClass</Type>
         </EventClass>
         <EventClass>
@@ -60745,9 +60765,6 @@ bM2L0PitchBusy : BOOL;
         <EventClass>
           <Type GUID="{1D0C4BAC-ECF3-4F33-8F20-A12E77AB6387}">Win32EventClass</Type>
         </EventClass>
-        <EventClass>
-          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
-        </EventClass>
       </EventClasses>
       <Properties>
         <Property>
@@ -60756,7 +60773,7 @@ bM2L0PitchBusy : BOOL;
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-05-02T14:38:07</Value>
+          <Value>2024-01-31T18:34:46</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- add `MR1L0_Pitch_ENC` variable.
- add `ULINT` to EL6695.
- Link and send encoder counts to arbiter. 
- add EP2008-0001 for variable cooling.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- arbiter needs encoder counts to veto/fault TXI. 
- EP2008 to service MR1 and MR2 L0 24V Solenoid valves.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- arbiter verified receipt of encoder counts.
- solenoid valves activated/deactivated.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-1410
## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
